### PR TITLE
Neo4j backend support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ README.html
 *.sqlite*
 *.db
 .coverage*
+caribou.cfg
+migrations/
+.idea/

--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@ Caribou SQLite Migrations
     <img src="http://imgur.com/DySrz.jpg" alt="Caribou" />
 </div>
 
-Caribou is a small, simple [SQLite][sqlite] database [migrations][rails] 
+Caribou is a small, simple [SQLite][sqlite] or [Neo4J][neo4j] database [migrations][rails] 
 library for [Python][python], built primarily to manage the evoluton of client
 side databases over multiple releases of an application.
 
   [rails]:http://guides.rubyonrails.org/migrations.html 
   [python]: http://python.org/
-  [sqlite]: http://sqlite.ord
+  [sqlite]: http://sqlite.org
+  [neo4j]: http://neo4j.com
 
 Example
 -------

--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ to add logging, DDL transactions, anything at all.
 
 Caribou migrations can be run with the command line tool:
 
-    $ caribou upgrade my_sqlite_db .
+    $ caribou upgrade -db my_sqlite_db -dir .
     upgrading db [my_sqlite_db] to most recent version
     upgraded [my_sqlite_db] successfully to version [20091115140758]
 
     # if you want to revert your changes, uses the downgrade command:
 
-    $ caribou downgrade my_sqlite_db . 0
+    $ caribou downgrade -db my_sqlite_db -dir . 0
     downgrading db [my_sqlite_db] to version [0]
     downgraded [my_sqlite_db] successfully to version [0]
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Example
 Here is a simple example illustrating how to use Caribou to manage your SQLite
 schema:
 
+#### Set up Config
+
+Create a `caribou.cfg` file that contains defaults for your database connection and migration directory. See `caribou.cfg.example` for an example.
+
 #### Create a Migration
 
 Use Caribou's command line tool to create your first migration:

--- a/bin/caribou
+++ b/bin/caribou
@@ -27,6 +27,7 @@ try:
     config.read('caribou.cfg')
     database_from_config = config.get("Caribou", 'db_url')
     migration_dir_from_config = config.get("Caribou", "migration_directory")
+    database_backend = getattr('caribou', config.get("Caribou", "backend"))
 except:
     database_from_config = 'file:data.db'
     migration_dir_from_config = './migrations'
@@ -48,38 +49,38 @@ def create_migration_command(args):
     Console.info("created migration %s" % path)
 
 def print_version_command(args):
-    db_path =  args.database_path
-    version = caribou.get_version(db_path)
-    msg = 'the db [%s] is not under version control' % db_path
+    database = args.database_backend(args.database_path)
+    version = caribou.get_version(database)
+    msg = 'the db [%s] is not under version control' % database
     if version:
-        msg = 'the db [%s] is at version %s' % (db_path, version)
+        msg = 'the db [%s] is at version %s' % (database, version)
     Console.info(msg)
 
 def upgrade_db_command(args):
-    db_path = args.database_path
+    database = args.database_backend(args.database_path)
     migration_dir = args.migration_dir
     version = args.version
-    msg = 'upgrading db [%s] to most recent version' % db_path
+    msg = 'upgrading db [%s] to most recent version' % database
     if version:
-        msg = 'upgrading db [%s] to version [%s]' % (db_path, version)
+        msg = 'upgrading db [%s] to version [%s]' % (database, version)
     Console.info(msg)
-    caribou.upgrade(db_path, migration_dir, version)
-    new_version = caribou.get_version(db_path)
+    caribou.upgrade(database, migration_dir, version)
+    new_version = caribou.get_version(database)
     if version:
         assert new_version == version
     msg = "upgraded [%s] successfully to version [%s]" % (
-                                    db_path, new_version)
+                                    database, new_version)
     Console.info(msg)
 
 def downgrade_db_command(args):
-    db_path = args.database_path
     migration_dir = args.migration_dir
     version = args.version
-    msg = 'downgrading db [%s] to version [%s]' % (db_path, version)
+    database = args.database_backend(args.database_path)
+    msg = 'downgrading db [%s] to version [%s]' % (database, version)
     Console.info(msg)
-    caribou.downgrade(db_path, migration_dir, version)
+    caribou.downgrade(database, migration_dir, version)
     msg = "downgraded [%s] successfully to version [%s]" % (
-                                db_path, version)
+                                database, version)
     Console.info(msg)
 
 def list_migrations_command(args):

--- a/bin/caribou
+++ b/bin/caribou
@@ -27,7 +27,7 @@ try:
     config.read('caribou.cfg')
     database_from_config = config.get("Caribou", 'db_url')
     migration_dir_from_config = config.get("Caribou", "migration_directory")
-    database_backend = getattr('caribou', config.get("Caribou", "backend"))
+    database_backend = getattr(caribou, config.get("Caribou", "backend"))
 except:
     database_from_config = 'file:data.db'
     migration_dir_from_config = './migrations'
@@ -49,7 +49,7 @@ def create_migration_command(args):
     Console.info("created migration %s" % path)
 
 def print_version_command(args):
-    database = args.database_backend(args.database_path)
+    database = database_backend(args.database_path)
     version = caribou.get_version(database)
     msg = 'the db [%s] is not under version control' % database
     if version:
@@ -57,7 +57,7 @@ def print_version_command(args):
     Console.info(msg)
 
 def upgrade_db_command(args):
-    database = args.database_backend(args.database_path)
+    database = database_backend(args.database_path)
     migration_dir = args.migration_dir
     version = args.version
     msg = 'upgrading db [%s] to most recent version' % database
@@ -75,7 +75,7 @@ def upgrade_db_command(args):
 def downgrade_db_command(args):
     migration_dir = args.migration_dir
     version = args.version
-    database = args.database_backend(args.database_path)
+    database = database_backend(args.database_path)
     msg = 'downgrading db [%s] to version [%s]' % (database, version)
     Console.info(msg)
     caribou.downgrade(database, migration_dir, version)

--- a/bin/caribou
+++ b/bin/caribou
@@ -101,9 +101,8 @@ def main():
     # add the create migration command
     create_cmd = commands.add_parser(CREATE_CMD, help=CREATE_CMD_HELP)
     create_cmd.add_argument(NAME, help=NAME_HELP)
-    create_cmd.add_argument(DIR, DIR_LONG, help=DIR_HELP)
+    create_cmd.add_argument(DIR, DIR_LONG, help=DIR_HELP, default=migration_dir_from_config)
     create_cmd.set_defaults(func=create_migration_command)
-    create_cmd.set_defaults(migration_dir='.')
     # add the version command
     version_cmd = commands.add_parser(VERSION_CMD, help=VERSION_CMD_HELP)
     version_cmd.add_argument(DB, DB_LONG, help=DB_HELP, default=database_from_config)

--- a/bin/caribou
+++ b/bin/caribou
@@ -8,6 +8,7 @@ database migrations library
 import os
 import sys
 import traceback
+import ConfigParser
 
 # 3p
 import argparse
@@ -19,6 +20,16 @@ import caribou
 
 EXIT_SUCCESS = 0
 EXIT_FAILURE = -1
+
+# config
+try:
+    config = ConfigParser.RawConfigParser()
+    config.read('caribou.cfg')
+    database_from_config = config.get("Caribou", 'db_url')
+    migration_dir_from_config = config.get("Caribou", "migration_directory")
+except:
+    database_from_config = 'file:data.db'
+    migration_dir_from_config = './migrations'
 
 class Console(object):
 
@@ -75,7 +86,7 @@ def list_migrations_command(args):
     migration_dir = args.migration_dir
     Console.info("Migrations in [%s]:" % migration_dir)
     Console.info("")
-    migrations = caribou.get_migrations(migration_dir)
+    migrations = caribou.load_migrations(migration_dir)
     for migration in migrations:
         version = migration.get_version()
         path = migration.path
@@ -94,24 +105,24 @@ def main():
     create_cmd.set_defaults(migration_dir='.')
     # add the version command
     version_cmd = commands.add_parser(VERSION_CMD, help=VERSION_CMD_HELP)
-    version_cmd.add_argument(DB, help=DB_HELP)
+    version_cmd.add_argument(DB, DB_LONG, help=DB_HELP, default=database_from_config)
     version_cmd.set_defaults(func=print_version_command)
     # add the upgrade command
     upgrade_cmd = commands.add_parser(UP_CMD, help=UP_CMD_HELP)
-    upgrade_cmd.add_argument(DB, help=DB_HELP)
-    upgrade_cmd.add_argument(DIR_ARG, help=DIR_HELP)
+    upgrade_cmd.add_argument(DB, DB_LONG, help=DB_HELP, default=database_from_config)
+    upgrade_cmd.add_argument(DIR, DIR_LONG, help=DIR_HELP, default=migration_dir_from_config)
     upgrade_cmd.add_argument(VERSION_OPT, VERSION_OPT_LONG, help=VERSION_HELP)
     upgrade_cmd.set_defaults(version=None)
     upgrade_cmd.set_defaults(func=upgrade_db_command)
     # add the downgrade command
     upgrade_cmd = commands.add_parser(DOWN_CMD, help=DOWN_CMD_HELP)
-    upgrade_cmd.add_argument(DB, help=DB_HELP)
-    upgrade_cmd.add_argument(DIR_ARG, help=DIR_HELP)
+    upgrade_cmd.add_argument(DB, DB_LONG, help=DB_HELP, default=database_from_config)
+    upgrade_cmd.add_argument(DIR, DIR_LONG, help=DIR_HELP, default=migration_dir_from_config)
     upgrade_cmd.add_argument(VERSION_ARG,  help=VERSION_HELP)
     upgrade_cmd.set_defaults(func=downgrade_db_command)
     # add the migration list command 
     list_cmd = commands.add_parser(LIST_CMD, help=LIST_CMD_HELP)
-    list_cmd.add_argument(DIR_ARG, help=DIR_HELP)
+    list_cmd.add_argument(DIR, DIR_LONG, help=DIR_HELP, default=migration_dir_from_config)
     list_cmd.set_defaults(func=list_migrations_command)
 
     args = parser.parse_args()
@@ -137,12 +148,12 @@ def main():
 
 # options/arguments
 
-DIR_ARG = 'migration_dir'
-DIR = '-d'
+DIR = '-dir'
 DIR_LONG = '--migration-dir'
 DIR_HELP = 'the migration directory'
 
-DB = 'database_path'
+DB = '-db'
+DB_LONG = '--database-path'
 DB_HELP = 'path to the sqlite database'
 
 NAME = 'name'

--- a/caribou.cfg.example
+++ b/caribou.cfg.example
@@ -1,3 +1,4 @@
 [Caribou]
-db_url = file:data.db
+backend = Neo4JDatabase
+db_url = http://user:password@host:port/db/data
 migration_directory = ./migrations

--- a/caribou.cfg.example
+++ b/caribou.cfg.example
@@ -1,0 +1,3 @@
+[Caribou]
+db_url = file:data.db
+migration_directory = ./migrations

--- a/caribou.py
+++ b/caribou.py
@@ -66,6 +66,20 @@ def transaction(conn):
         msg = "Error in transaction: %s" % traceback.format_exc()
         raise Error(msg)
 
+@contextlib.contextmanager
+def close_if_we_can(conn):
+    """
+    Close the connection if it has a close method. Since we support backends whose API do not provide
+    conn.close() methods, using this instead of contextlib.close
+    :param conn: Connection to a database; result of Database.connect()
+    :return:
+    """
+    try:
+        yield
+        conn.close()
+    except AttributeError:
+        pass
+
 def has_method(an_object, method_name):
     return hasattr(an_object, method_name) and \
                     callable(getattr(an_object, method_name))
@@ -242,9 +256,6 @@ class Neo4JDatabase(BaseDatabase):
         self.db_url = db_url
         self.conn = py2neo.Graph(db_url)
 
-    def close(self):
-        pass
-
     def is_version_controlled(self, *args, **kwargs):
         result = self.execute("MATCH (n:Migration) return count(n)")
         return bool(result[0][0])
@@ -264,6 +275,9 @@ class Neo4JDatabase(BaseDatabase):
     def initialize_version_control(self):
         self.execute("CREATE (n:Migration)")
 
+    def connect(self):
+        return self.conn
+
 def _assert_migration_exists(migrations, version):
     if version not in (m.get_version() for m in migrations):
         raise Error('No migration with version %s exists.' % version)
@@ -282,7 +296,7 @@ def upgrade(database, migration_dir, version=None):
         migrations directory. If a version is not specified, upgrade
         to the most recent version.
     """
-    with contextlib.closing(database.connect()) as db:
+    with close_if_we_can(database.connect()) as db:
         if not db.is_version_controlled():
             db.initialize_version_control()
         migrations = load_migrations(migration_dir)
@@ -292,7 +306,7 @@ def downgrade(database, migration_dir, version):
     """ Downgrade the database to the given version with the migrations
         contained in the given migration directory.
     """
-    with contextlib.closing(database.connect()) as db:
+    with close_if_we_can(database.connect()) as db:
         if not db.is_version_controlled():
             msg = "The database %s is not version controlled." % (database.db_url)
             raise Error(msg)
@@ -301,7 +315,7 @@ def downgrade(database, migration_dir, version):
 
 def get_version(database):
     """ Return the migration version of the given database. """
-    with contextlib.closing(database.connect()) as db:
+    with close_if_we_can(database.connect()) as db:
         return db.get_version()
 
 def create_migration(name, directory=None):

--- a/caribou.py
+++ b/caribou.py
@@ -264,6 +264,9 @@ class Neo4JDatabase(BaseDatabase):
     def initialize_version_control(self):
         self.execute("CREATE (n:Migration)")
 
+    def connect(self):
+        return self
+
 def _assert_migration_exists(migrations, version):
     if version not in (m.get_version() for m in migrations):
         raise Error('No migration with version %s exists.' % version)

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,9 @@ setup( name = NAME
      , py_modules=['caribou']
      , scripts=['bin/caribou']
      , install_requires=["argparse>=1.0.0"]
+     , extras_require={
+        "neo4j": ['py2neo']
+    }
      , classifiers=\
          [ 'Development Status :: 4 - Beta'
          , 'Intended Audience :: Developers'


### PR DESCRIPTION
# Background

See issue https://github.com/industrydive/datadive/issues/236. We want to be able to specify arbitrary python migrations in a migration system that can preserve state in the database that is being migrated and understand chronology between migrations.
# Implementation

Supports neo4j in caribou by providing a new Database class that uses py2neo and cypher to A) version the database with a `:Migration` node and B) execute migration scripts on a py2neo.Graph connection object.

To make the CLI easier to use and the ability to switch out between the backends, I also added a config scheme using ConfigParser so we can have defaults for migration dir, database URL, and backend type.
# Testing
- You can do this in a virtualenv, or inside the webserver container for datadive. Install this from git with py2neo driver support with `pip install git+ssh://github.com/industrydive/caribou.git@neo4j-support#egg=Caribou[neo4j]`
- Specify a `caribou.cfg` in the root dir that looks like this with your database url and migrations dir specified (you must create the migrations dir if it does not already exist.)
- Create some migrations... `caribou create a_migration` and `caribou create a_second_migration`. Should put this in your migrations directory specified in the config or default to `./migrations`.
- Put some logic into the upgrade and downgrade migrations. Maybe like...

``` python
#*_a_migration.py
def upgrade(connection):
    # add your upgrade step here
    connection.cypher.execute("CREATE (n:Test {level: 1})")

def downgrade(connection):
    # add your downgrade step here
    pass

#*_a_second_migration.py
def upgrade(connection):
    # add your upgrade step here
    connection.cypher.execute("CREATE (n:Test {level: 2})")

def downgrade(connection):
    # add your downgrade step here
    connection.cypher.execute("MATCH (n:Test {level:2}) delete n")
```
- Upgrade with `caribou upgrade`. Go check out your database you had specified in you cfg for the `:Migration` node and whatever you added in your test migrations; if you followed my example you should have 2 `:Test` nodes in there as well.
- Downgrade with `caribou downgrade {version}`. You can pull the version you want to downgrade to off the migration file header. See that the `:Migration` node changed and the downgrade logic occured i.e. the second `:Test` node was deleted in the event you copied my example migrations.
- Try out `caribou list` to see what migrations you have locally.
- How about `caribou version` to get the current version from the database.
# TODO
- [x] can probably abstract downgrade() and upgrade() since they are straight up copy paste in here.
- [x] update tests?
