### PR TITLE
(closes #4) Allow socket_timeout to be configurable

### DIFF
--- a/bin/caribou
+++ b/bin/caribou
@@ -9,6 +9,7 @@ import os
 import sys
 import traceback
 import ConfigParser
+import io
 
 # 3p
 import argparse
@@ -22,10 +23,16 @@ EXIT_SUCCESS = 0
 EXIT_FAILURE = -1
 
 # config
-config = ConfigParser.SafeConfigParser(defaults={"db_url": "file:data.db",
-                                                 "migration_directory": "./migrations",
-                                                 "backend": "SQLiteDatabase",
-                                                 "socket_timeout": None})
+default_config = """
+[Caribou]
+db_url=file:data.db
+migration_directory: ./migrations
+backend: SQLiteDatabase
+socket_timeout: 30"""
+config = ConfigParser.SafeConfigParser()
+# load default config. see https://docs.python.org/2/library/configparser.html#examples
+config.readfp(io.BytesIO(default_config))
+# load local config file if we have it. will silently fail
 config.read('caribou.cfg')
 database_from_config = config.get("Caribou", 'db_url')
 migration_dir_from_config = config.get("Caribou", "migration_directory")

--- a/bin/caribou
+++ b/bin/caribou
@@ -30,7 +30,7 @@ config.read('caribou.cfg')
 database_from_config = config.get("Caribou", 'db_url')
 migration_dir_from_config = config.get("Caribou", "migration_directory")
 database_backend = getattr(caribou, config.get("Caribou", "backend"))
-socket_timeout = config.get("Caribou", "socket_timeout")
+socket_timeout = int(config.get("Caribou", "socket_timeout"))
 
 
 class Console(object):

--- a/bin/caribou
+++ b/bin/caribou
@@ -22,15 +22,16 @@ EXIT_SUCCESS = 0
 EXIT_FAILURE = -1
 
 # config
-try:
-    config = ConfigParser.RawConfigParser()
-    config.read('caribou.cfg')
-    database_from_config = config.get("Caribou", 'db_url')
-    migration_dir_from_config = config.get("Caribou", "migration_directory")
-    database_backend = getattr(caribou, config.get("Caribou", "backend"))
-except:
-    database_from_config = 'file:data.db'
-    migration_dir_from_config = './migrations'
+config = ConfigParser.SafeConfigParser(defaults={"db_url": "file:data.db",
+                                                 "migration_directory": "./migrations",
+                                                 "backend": "SQLiteDatabase",
+                                                 "socket_timeout": None})
+config.read('caribou.cfg')
+database_from_config = config.get("Caribou", 'db_url')
+migration_dir_from_config = config.get("Caribou", "migration_directory")
+database_backend = getattr(caribou, config.get("Caribou", "backend"))
+socket_timeout = config.get("Caribou", "socket_timeout")
+
 
 class Console(object):
 
@@ -57,7 +58,7 @@ def print_version_command(args):
     Console.info(msg)
 
 def upgrade_db_command(args):
-    database = database_backend(args.database_path)
+    database = database_backend(args.database_path, socket_timeout)
     migration_dir = args.migration_dir
     version = args.version
     msg = 'upgrading db [%s] to most recent version' % database
@@ -75,7 +76,7 @@ def upgrade_db_command(args):
 def downgrade_db_command(args):
     migration_dir = args.migration_dir
     version = args.version
-    database = database_backend(args.database_path)
+    database = database_backend(args.database_path, socket_timeout)
     msg = 'downgrading db [%s] to version [%s]' % (database, version)
     Console.info(msg)
     caribou.downgrade(database, migration_dir, version)

--- a/caribou.cfg.example
+++ b/caribou.cfg.example
@@ -2,3 +2,4 @@
 backend = Neo4JDatabase
 db_url = http://user:password@host:port/db/data
 migration_directory = ./migrations
+socket_timeout = 901

--- a/caribou.py
+++ b/caribou.py
@@ -16,11 +16,9 @@ import os.path
 import sqlite3
 try:
     import py2neo
-except:
+except ImportError:
     pass # not running neo4j option
 import traceback
-import ConfigParser
-import sys
 
 # statics
 
@@ -247,7 +245,6 @@ class Neo4JDatabase(BaseDatabase):
         """
         self.db_url = db_url
         if socket_timeout:
-            import py2neo.packages.httpstream.http
             py2neo.packages.httpstream.http.socket_timeout = socket_timeout
         self.conn = py2neo.Graph(db_url)
 

--- a/caribou.py
+++ b/caribou.py
@@ -190,7 +190,7 @@ class BaseDatabase(object):
 
 class SQLiteDatabase(BaseDatabase):
 
-    def __init__(self, db_url):
+    def __init__(self, db_url, *args, **kwargs):
         self.db_url = db_url
         self.conn = self.connect()
         
@@ -238,8 +238,17 @@ class Neo4JDatabase(BaseDatabase):
     Assumes there are no nodes in target database whose label is :Migration
     """
 
-    def __init__(self, db_url):
+    def __init__(self, db_url, socket_timeout=None, *args, **kwargs):
+        """
+        :param db_url: URL string to pass to a py2neo.Graph instance to connect to a neo4j database
+        :type db_url: str
+        :param socket_timeout: integer in seconds of how long to ovverride py2neo's http timeout to
+        :type socket_timeout: int
+        """
         self.db_url = db_url
+        if socket_timeout:
+            import py2neo.packages.httpstream.http
+            py2neo.packages.httpstream.http.socket_timeout = socket_timeout
         self.conn = py2neo.Graph(db_url)
 
     def close(self):


### PR DESCRIPTION
See issue #4. 

This PR exposes `py2neo.packages.httpstream.http.socket_timeout` as a parameter you can set in your `caribou.cfg` file. It also cleans up some of the ConfigParser stuff because I was using a deprecated version of ConfigParser that was lame.
